### PR TITLE
Enable Add to Wallet button for non-iOS devices with warning messages

### DIFF
--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -43,6 +43,7 @@ function Form(): JSX.Element {
 
     const [isDisabledAppleWallet, setIsDisabledAppleWallet] = useState<boolean>(false);
     const [errorMessages, _setErrorMessages] = useState<Array<string>>([]);
+    const [warningMessages, _setWarningMessages] = useState<Array<string>>([]);
     const hitcountHost = 'https://stats.vaccine-ontario.ca';
 
 
@@ -83,6 +84,15 @@ function Form(): JSX.Element {
         const translation = t('errors:'.concat(message));
         _setErrorMessages(Array.from(new Set([...errorMessages, translation !== message ? translation : message])));
     };
+
+    const setWarningMessage = (message: string) => {
+        if (message == undefined) {
+            return;
+        }
+
+        const translation = t('errors:'.concat(message));
+        _setWarningMessages(Array.from(new Set([...warningMessages, translation !== message ? translation : message])));
+    }
 
     const deleteErrorMessage = (message: string) =>{
         console.log(errorMessages)
@@ -328,6 +338,10 @@ function Form(): JSX.Element {
             setErrorMessage('Sorry, only Safari can be used to add a Wallet Pass on iOS');
             setIsDisabledAppleWallet(true);
             console.log('not safari')
+        } else if (!isIOS) {
+            setWarningMessage('Only Safari is officially supported at the moment. ' +
+                'Please download a compitable apps on other platform to open .pkpass');
+            setIsDisabledAppleWallet(false);
         }
     }
 
@@ -437,6 +451,9 @@ function Form(): JSX.Element {
                         </div>
                         {errorMessages.map((message, i) =>
                             <Alert message={message} key={'error-' + i} type="error" />
+                        )}
+                        {warningMessages.map((message, i) =>
+                            <Alert message={message} key={'warning-' + i} type="warning" />
                         )}
                     </div>
                 }/>

--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -86,7 +86,7 @@ function Form(): JSX.Element {
     };
 
     const setWarningMessage = (message: string) => {
-        if (message == undefined) {
+        if (!message) {
             return;
         }
 

--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -77,7 +77,7 @@ function Form(): JSX.Element {
 
     // Check if there is a translation and replace message accordingly
     const setErrorMessage = (message: string) => {
-        if (message == undefined) {
+        if (!message) {
             return;
         }
 

--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -339,8 +339,8 @@ function Form(): JSX.Element {
             setIsDisabledAppleWallet(true);
             console.log('not safari')
         } else if (!isIOS) {
-            setWarningMessage('Only Safari is officially supported at the moment. ' +
-                'Please download a compitable apps on other platform to open .pkpass');
+            setWarningMessage('Only Safari on iOS is officially supported for Wallet import at the moment - ' +
+                'for other platforms, please ensure you have an application which can open Apple Wallet .pkpass files');
             setIsDisabledAppleWallet(false);
         }
     }


### PR DESCRIPTION
As stated in #7, there are other apps besides iOS devices that support `.pkpass` file type. We want the app to be used as widely as possible. Therefore, it makes sense to allow other devices to download the file and add to their devices. 
A warning message is displayed when device is non-Apple as we cannot guarantee whether such device do support the file type. If user choose to download the file and unable to add to their apps it will be up to them to find a compatible apps.

PS. I am unable to build the project using the README instructions. If anyone can test this out it will be appricated.