### PR TITLE
Stop splitting vaccinename so we can detect AZ correctly

### DIFF
--- a/src/payload.ts
+++ b/src/payload.ts
@@ -58,8 +58,7 @@ export class Payload {
             vaccineNameProper = 'Pfizer (Comirnaty)'
 
         if (vaccineName.includes('MODERNA'))
-            vaccineNameProper = 'Moderna (SpikeVax)'    
-            // vaccineNameProper = 'Pfizer (Comirnaty)'
+            vaccineNameProper = 'Moderna (SpikeVax)'
 
         if (vaccineName.includes('ASTRAZENECA') || vaccineName.includes('COVISHIELD'))
             vaccineNameProper = 'AstraZeneca (Vaxzevria)'  

--- a/src/process.ts
+++ b/src/process.ts
@@ -120,8 +120,6 @@ async function loadPDF(signedPdfBuffer : ArrayBuffer): Promise<HashTable<Receipt
         }
         return Promise.reject(e);
     }
-
-
 }
 
 async function getPdfDetails(fileBuffer: ArrayBuffer): Promise<HashTable<Receipt>> {
@@ -152,7 +150,6 @@ async function getPdfDetails(fileBuffer: ArrayBuffer): Promise<HashTable<Receipt
                 }
                 if (value.includes('Product name')) {
                     vaccineName = (content.items[i+1] as TextItem).str;
-                    vaccineName = vaccineName.split(' ')[0];
                 }
                 if (value.includes('Date of birth'))
                     dateOfBirth = (content.items[i+1] as TextItem).str;
@@ -169,5 +166,4 @@ async function getPdfDetails(fileBuffer: ArrayBuffer): Promise<HashTable<Receipt
         Sentry.captureException(e);
         return Promise.reject(e);
     }
-
 }


### PR DESCRIPTION
* Because we were splitting on space, "COVID-19 COVISHIELD"  was being converted to
  just "COVID-19" which broke AZ detection for Covishield